### PR TITLE
Add notebook to browse labeled sample entries

### DIFF
--- a/notebooks/review_labeled_sample.ipynb
+++ b/notebooks/review_labeled_sample.ipynb
@@ -1,0 +1,66 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "import ipywidgets as widgets\n",
+        "from IPython.display import display\n\n",
+        "df = pd.read_csv('data/labeled_sample.csv')\n",
+        "total_rows = len(df)\n",
+        "print(f'Loaded {total_rows} entries from labeled_sample.csv')\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "current_index = 0\n",
+        "index_display = widgets.IntText(value=current_index, description='Index', disabled=True)\n",
+        "progress_label = widgets.Label()\n",
+        "output = widgets.Output()\n\n",
+        "def show_entry(idx: int) -> None:\n",
+        "    global current_index\n",
+        "    current_index = idx\n",
+        "    index_display.value = current_index\n",
+        "    progress_label.value = f'Entry {current_index + 1} of {total_rows}'\n",
+        "    with output:\n",
+        "        output.clear_output()\n",
+        "        display(df.iloc[[current_index]])\n",
+        "    prev_button.disabled = current_index == 0\n",
+        "    next_button.disabled = current_index >= total_rows - 1\n\n",
+        "def on_prev(_):\n",
+        "    if current_index > 0:\n",
+        "        show_entry(current_index - 1)\n\n",
+        "def on_next(_):\n",
+        "    if current_index < total_rows - 1:\n",
+        "        show_entry(current_index + 1)\n\n",
+        "prev_button = widgets.Button(description='Previous')\n",
+        "next_button = widgets.Button(description='Next', button_style='primary')\n",
+        "prev_button.on_click(on_prev)\n",
+        "next_button.on_click(on_next)\n\n",
+        "controls = widgets.HBox([prev_button, next_button, progress_label, index_display])\n\n",
+        "show_entry(current_index)\n",
+        "display(controls, output)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add an interactive Jupyter notebook for stepping through `labeled_sample.csv`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e47c8ed8d083209d8eae93634adb51